### PR TITLE
Feature/hyperledger fabric 2.5.10

### DIFF
--- a/hyperledger-fabric/orderer/Makefile
+++ b/hyperledger-fabric/orderer/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-APP_VERSION := 2.5.0
+APP_VERSION := 2.5.10
 
 build: package tag
 

--- a/hyperledger-fabric/orderer/README.md
+++ b/hyperledger-fabric/orderer/README.md
@@ -30,6 +30,7 @@ docker pull nimbostack/hyperledger-fabric-orderer:2.5.0
 NimboStack Hyperledger Fabric Orderer images are available starting from version 2.5.0. Supported tags include:
 
 - `2.5.0`
+- `2.5.10`
 
 ## Issues
 

--- a/hyperledger-fabric/orderer/apko.yaml
+++ b/hyperledger-fabric/orderer/apko.yaml
@@ -19,12 +19,12 @@ annotations:
   org.opencontainers.image.authors: Nimbostack
   org.opencontainers.image.title: "hyperledger-fabric-orderer"
   org.opencontainers.image.ref.name: hyperledger-fabric-orderer
-  org.hyperledger.fabric.version: "2.5.0"
+  org.hyperledger.fabric.version: "2.5.10"
   org.opencontainers.image.base.name: "wolfi"
   org.opencontainers.image.description: "Hyperledger Fabric Orderer application packaged by Nimbostack"
   org.opencontainers.image.licenses: "Apache-2.0"
   org.opencontainers.image.vendor: "Nimbostack"
-  org.opencontainers.image.version: "2.5.0"
+  org.opencontainers.image.version: "2.5.10"
   org.opencontainers.image.source: "github.com/Nimbostack/blockstax-containers/tree/main/hyperledger-fabric/orderer"
   org.opencontainers.image.documentation: "github.com/Nimbostack/blockstax-containers/tree/main/hyperledger-fabric/orderer/README.md"
 

--- a/hyperledger-fabric/orderer/melange.yaml
+++ b/hyperledger-fabric/orderer/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: hyperledger-fabric-orderer
-  version: 2.5.0
+  version: 2.5.10
   epoch: 0
   description: A package for a Hyperledger Fabric Orderer
   target-architecture:

--- a/hyperledger-fabric/peer/Makefile
+++ b/hyperledger-fabric/peer/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-APP_VERSION:=2.5.0
+APP_VERSION:=2.5.10
 
 build: package tag
 

--- a/hyperledger-fabric/peer/README.md
+++ b/hyperledger-fabric/peer/README.md
@@ -30,6 +30,7 @@ docker pull nimbostack/hyperledger-fabric-peer:2.5.0
 NimboStack Hyperledger Fabric Peer images are available starting from version 2.5.0. Supported tags include:
 
 - `2.5.0`
+- `2.5.10`
 
 ## Issues
 

--- a/hyperledger-fabric/peer/apko.yaml
+++ b/hyperledger-fabric/peer/apko.yaml
@@ -10,7 +10,7 @@ contents:
 
 environment:
   FABRIC_CFG_PATH: /etc/hyperledger/fabric
-  FABRIC_VER: 2.5.0
+  FABRIC_VER: 2.5.10
   PATH: /usr/local/bin:/usr/sbin:/sbin:/usr/bin:/bin:/opt/hyperledger/ccaas_builder/bin
 
 annotations:
@@ -20,11 +20,11 @@ annotations:
   org.opencontainers.image.description: "Hyperledger Fabric Peer application packaged by Nimbostack"
   org.opencontainers.image.licenses: "Apache-2.0"
   org.opencontainers.image.vendor: "Nimbostack"
-  org.opencontainers.image.version: "2.5.0"
+  org.opencontainers.image.version: "2.5.10"
   org.opencontainers.image.source: "github.com/Nimbostack/blockstax-containers/tree/main/hyperledger-fabric/peer"
   org.opencontainers.image.documentation: "github.com/Nimbostack/blockstax-containers/tree/main/hyperledger-fabric/peer/README.md"
   org.opencontainers.image.ref.name: hyperledger-fabric-peer
-  org.hyperledger.fabric.version: "2.5.0"
+  org.hyperledger.fabric.version: "2.5.10"
 
 
 entrypoint:

--- a/hyperledger-fabric/peer/melange.yaml
+++ b/hyperledger-fabric/peer/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: hyperledger-fabric-peer
-  version: 2.5.0
+  version: 2.5.10
   epoch: 0
   description: A package for a Hyperledger Fabric Peer
   target-architecture: [x86_64, aarch64]

--- a/hyperledger-fabric/tools/Makefile
+++ b/hyperledger-fabric/tools/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-APP_VERSION := 2.5.0
+APP_VERSION := 2.5.10
 
 build: package tag
 

--- a/hyperledger-fabric/tools/README.md
+++ b/hyperledger-fabric/tools/README.md
@@ -28,6 +28,7 @@ docker pull nimbostack/hyperledger-fabric-tools:2.5.0
 NimboStack Hyperledger Fabric Tools images are available starting from version 2.5.0. Supported tags include:
 
 - `2.5.0`
+- `2.5.10`
 
 ## Issues
 

--- a/hyperledger-fabric/tools/apko.yaml
+++ b/hyperledger-fabric/tools/apko.yaml
@@ -15,12 +15,12 @@ environment:
 annotations:
   org.opencontainers.image.authors: Nimbostack
   org.opencontainers.image.title: "hyperledger-fabric-tools"
-  org.hyperledger.fabric.version: "2.5.0"
+  org.hyperledger.fabric.version: "2.5.10"
   org.opencontainers.image.base.name: "wolfi"
   org.opencontainers.image.description: "Hyperledger Fabric Tools application packaged by Nimbostack"
   org.opencontainers.image.licenses: "Apache-2.0"
   org.opencontainers.image.vendor: "Nimbostack"
-  org.opencontainers.image.version: "2.5.0"
+  org.opencontainers.image.version: "2.5.10"
   org.opencontainers.image.source: "github.com/Nimbostack/blockstax-containers/tree/main/hyperledger-fabric/tools"
   org.opencontainers.image.documentation: "github.com/Nimbostack/blockstax-containers/tree/main/hyperledger-fabric/tools/README.md"
   org.opencontainers.image.ref.name: hyperledger-fabric-tools

--- a/hyperledger-fabric/tools/melange.yaml
+++ b/hyperledger-fabric/tools/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: hyperledger-fabric-tools
-  version: 2.5.0
+  version: 2.5.10
   epoch: 0
   description: A package for Hyperledger Fabric Tools
   target-architecture: [x86_64, aarch64]


### PR DESCRIPTION
## Description
 
upgrade from current hyperledger fabric version `2.5.0` for peer, orderer, tools to version `2.5.10` 

## How Has This Been Tested?

Ran all the pipelines for melange, and apko to verify that this upgrade will be able to publish successfully.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update